### PR TITLE
fix-docs-links

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ In addition to the standard API services, there are also admin services that req
 
 You can access help for every service and command by using `--help` or `-h`. If you encounter any issues not covered in the help prompt, or if you have suggestions for improvement, please feel free to [contact us](mailto:support@metal-stack.io) or open an issue in this repository. Your feedback is greatly appreciated!
 
-A list of all available services (excluding admin topics). For their associated commands, arguments and flags visit the correct [documentation](./docs/metal.md).
+A list of all available services (excluding admin topics). For their associated commands, arguments and flags visit the [metalctlv2 documentation](./docs/metalctlv2.md).
 
 | Entity        | Description                                                | Documentation                                         |
 |---------------|------------------------------------------------------------|-------------------------------------------------------|

--- a/docs/metalctlv2_tenant_invite.md
+++ b/docs/metalctlv2_tenant_invite.md
@@ -26,6 +26,5 @@ manage tenant invites
 * [metalctlv2 tenant](metalctlv2_tenant.md)	 - manage tenant entities
 * [metalctlv2 tenant invite delete](metalctlv2_tenant_invite_delete.md)	 - deletes a pending invite
 * [metalctlv2 tenant invite generate-join-secret](metalctlv2_tenant_invite_generate-join-secret.md)	 - generate an invite secret to share with the new member
-* [metalctlv2 tenant invite join](metalctlv2_tenant_invite_join.md)	 - join a tenant of someone who shared an invite secret with you
 * [metalctlv2 tenant invite list](metalctlv2_tenant_invite_list.md)	 - lists the currently pending invites
 


### PR DESCRIPTION
Fix links in the documentation:
- Use proper filename in README.md for metalctlv2.md
- There is no page for "metalctlv2_tenant_invite_join.md". We can decide whether to delete it or link it to "metalctlc2_tenant_join.md"

