### PR TITLE
Prune components

### DIFF
--- a/cmd/admin/v2/component.go
+++ b/cmd/admin/v2/component.go
@@ -1,9 +1,10 @@
 package v2
 
 import (
+	"context"
 	"fmt"
+	"time"
 
-	"github.com/metal-stack/api/go/enum"
 	adminv2 "github.com/metal-stack/api/go/metalstack/admin/v2"
 	apiv2 "github.com/metal-stack/api/go/metalstack/api/v2"
 	"github.com/metal-stack/cli/cmd/config"
@@ -36,10 +37,23 @@ func newComponentCmd(c *config.Config) *cobra.Command {
 			cmd.Flags().String("uuid", "", "lists only component with this uuid")
 			cmd.Flags().String("type", "", "lists only component of this type")
 			cmd.Flags().String("identifier", "", "lists only component with this identifier")
+			genericcli.Must(cmd.RegisterFlagCompletionFunc("type", c.Completion.ComponentTypes))
 		},
 	}
+	pruneCmd := &cobra.Command{
+		Use:   "prune",
+		Short: "prune outdated component entries",
+		Long:  "prune outdated component entries to shorten the component list",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return w.prune(cmd.Context())
+		},
+		ValidArgsFunction: c.Completion.Firewall,
+	}
+	pruneCmd.Flags().Duration("max-age", 12*time.Hour, "prune all components which are older than max-age and not active anymore")
+	pruneCmd.Flags().String("type", "", "prune only component of this type")
+	genericcli.Must(pruneCmd.RegisterFlagCompletionFunc("type", c.Completion.ComponentTypes))
 
-	return genericcli.NewCmds(cmdsConfig)
+	return genericcli.NewCmds(cmdsConfig, pruneCmd)
 }
 
 func (c *component) Get(id string) (*apiv2.Component, error) {
@@ -83,11 +97,12 @@ func (c *component) List() ([]*apiv2.Component, error) {
 	}
 
 	if viper.IsSet("type") {
-		t, err := enum.GetEnum[apiv2.ComponentType](viper.GetString("type"))
-		if err != nil {
-			return nil, fmt.Errorf("unable to get component type of string %q %w", viper.GetString("type"), err)
+		componentString := viper.GetString("type")
+		ct, ok := apiv2.ComponentType_value[componentString]
+		if !ok {
+			return nil, fmt.Errorf("unknown component type: %s", componentString)
 		}
-		query.Type = &t
+		query.Type = new(apiv2.ComponentType(ct))
 	}
 
 	req := &adminv2.ComponentServiceListRequest{Query: query}
@@ -99,6 +114,38 @@ func (c *component) List() ([]*apiv2.Component, error) {
 
 	return resp.Components, nil
 }
+
+func (c *component) prune(ctx context.Context) error {
+	components, err := c.List()
+	if err != nil {
+		return err
+	}
+
+	maxAge := viper.GetDuration("max-age")
+
+	for _, ct := range components {
+		if time.Since(ct.ReportedAt.AsTime()) < maxAge {
+			if time.Until(ct.Token.Expires.AsTime()) > 0 {
+				continue
+			}
+		}
+
+		req := &adminv2.ComponentServiceDeleteRequest{
+			Uuid: ct.Uuid,
+		}
+		resp, err := c.c.Client.Adminv2().Component().Delete(ctx, req)
+		if err != nil {
+			return fmt.Errorf("failed to prune components: %w", err)
+		}
+		_, err = fmt.Fprintf(c.c.Out, "deleted component %s:%s\n", resp.Component.Uuid, resp.Component.Identifier)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 func (c *component) Convert(r *apiv2.Component) (string, any, any, error) {
 	panic("unimplemented")
 }

--- a/cmd/admin/v2/component.go
+++ b/cmd/admin/v2/component.go
@@ -121,7 +121,10 @@ func (c *component) prune(ctx context.Context) error {
 		return err
 	}
 
-	maxAge := viper.GetDuration("max-age")
+	var (
+		maxAge           = viper.GetDuration("max-age")
+		prunedComponents []*apiv2.Component
+	)
 
 	for _, ct := range components {
 		if time.Since(ct.ReportedAt.AsTime()) < maxAge {
@@ -137,13 +140,10 @@ func (c *component) prune(ctx context.Context) error {
 		if err != nil {
 			return fmt.Errorf("failed to prune components: %w", err)
 		}
-		_, err = fmt.Fprintf(c.c.Out, "deleted component %s:%s\n", resp.Component.Uuid, resp.Component.Identifier)
-		if err != nil {
-			return err
-		}
+		prunedComponents = append(prunedComponents, resp.Component)
 	}
 
-	return nil
+	return c.c.ListPrinter.Print(prunedComponents)
 }
 
 func (c *component) Convert(r *apiv2.Component) (string, any, any, error) {

--- a/cmd/completion/component.go
+++ b/cmd/completion/component.go
@@ -1,0 +1,16 @@
+package completion
+
+import (
+	apiv2 "github.com/metal-stack/api/go/metalstack/api/v2"
+	"github.com/spf13/cobra"
+)
+
+func (c *Completion) ComponentTypes(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	var names []string
+
+	for _, name := range apiv2.ComponentType_name {
+		names = append(names, name)
+	}
+
+	return names, cobra.ShellCompDirectiveNoFileComp
+}

--- a/tests/e2e/admin/component_test.go
+++ b/tests/e2e/admin/component_test.go
@@ -106,6 +106,63 @@ d2b3c4e5-f6a7-8901-bcde-f12345678901 pixiecore-1
 	}
 }
 
+func Test_AdminComponentCmd_Prune(t *testing.T) {
+	tests := []*e2e.Test[adminv2.ComponentServiceListResponse, apiv2.Component]{
+		{
+			Name:    "prune",
+			CmdArgs: []string{"admin", "component", "prune"},
+			NewRootCmd: e2erootcmd.NewRootCmd(t, &e2erootcmd.TestConfig{
+				ClientCalls: []client.ClientCall{
+					{
+						WantRequest: &adminv2.ComponentServiceListRequest{
+							Query: &apiv2.ComponentQuery{},
+						},
+						WantResponse: func() connect.AnyResponse {
+							return connect.NewResponse(&adminv2.ComponentServiceListResponse{
+								Components: []*apiv2.Component{
+									testresources.Component1(),
+									testresources.Component2(),
+									testresources.Component3(),
+								},
+							})
+						},
+					},
+					{
+						WantRequest: &adminv2.ComponentServiceDeleteRequest{
+							Uuid: testresources.Component3().Uuid,
+						},
+						WantResponse: func() connect.AnyResponse {
+							return connect.NewResponse(&adminv2.ComponentServiceDeleteResponse{
+								Component: testresources.Component3(),
+							})
+						},
+					},
+				},
+			}),
+			WantTable: new(`
+            ID                                    TYPE           IDENTIFIER       STARTED  AGE  VERSION  TOKEN                                 TOKEN EXPIRES IN  
+            d2b3c4e5-f6a7-8901-bcde-f12345678903  metal-console  metal-console-1  0s       0s   v2.0.0   t2b3c4e5-f6a7-8901-bcde-f12345678903  -2d
+			`),
+			WantWideTable: new(`
+            ID                                    TYPE           IDENTIFIER       STARTED  AGE  VERSION  TOKEN                                 TOKEN EXPIRES IN  
+            d2b3c4e5-f6a7-8901-bcde-f12345678903  metal-console  metal-console-1  0s       0s   v2.0.0   t2b3c4e5-f6a7-8901-bcde-f12345678903  -2d
+			`),
+			Template: new("{{ .uuid }} {{ .identifier }}"),
+			WantTemplate: new(`
+d2b3c4e5-f6a7-8901-bcde-f12345678903 metal-console-1
+`),
+			WantMarkdown: new(`
+            | ID                                   | TYPE          | IDENTIFIER      | STARTED | AGE | VERSION | TOKEN                                | TOKEN EXPIRES IN |
+            |--------------------------------------|---------------|-----------------|---------|-----|---------|--------------------------------------|------------------|
+            | d2b3c4e5-f6a7-8901-bcde-f12345678903 | metal-console | metal-console-1 | 0s      | 0s  | v2.0.0  | t2b3c4e5-f6a7-8901-bcde-f12345678903 | -2d              |
+			`),
+		},
+	}
+	for _, tt := range tests {
+		tt.TestCmd(t)
+	}
+}
+
 func Test_AdminComponentCmd_Delete(t *testing.T) {
 	tests := []*e2e.Test[adminv2.ComponentServiceDeleteResponse, *apiv2.Component]{
 		{

--- a/tests/e2e/testresources/component.go
+++ b/tests/e2e/testresources/component.go
@@ -44,4 +44,21 @@ var (
 			},
 		}
 	}
+	Component3 = func() *apiv2.Component {
+		return &apiv2.Component{
+			Uuid:       "d2b3c4e5-f6a7-8901-bcde-f12345678903",
+			Type:       apiv2.ComponentType_COMPONENT_TYPE_METAL_CONSOLE,
+			Identifier: "metal-console-1",
+			StartedAt:  timestamppb.New(e2e.TimeBubbleStartTime()),
+			ReportedAt: timestamppb.New(e2e.TimeBubbleStartTime()),
+			Interval:   durationpb.New(10 * time.Second),
+			Version: &apiv2.Version{
+				Version: "v2.0.0",
+			},
+			Token: &apiv2.Token{
+				Uuid:    "t2b3c4e5-f6a7-8901-bcde-f12345678903",
+				Expires: timestamppb.New(e2e.TimeBubbleStartTime().Add(-48 * time.Hour)),
+			},
+		}
+	}
 )


### PR DESCRIPTION
## Description

Add ability to prune components which are present with a expired token.

#### Used AI-Tools ✨

<!-- If not used, delete the next section.

For commits with substantial parts that were generated by AI, please also mark the commits with the Generated-By: [tool name] label as described in our contribution guideline: https://metal-stack.io/community/contribution-guideline/#usage-of-generative-ai-tools.
 -->

- none used for generation

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
You maybe want to attach the triage label if you want it to be discussed in the next planning meeting. It might be useful to attend the meeting if you want to emphasize it.

If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
