### PR TITLE
Generic enum completion, switch os in list view

### DIFF
--- a/cmd/completion/audit.go
+++ b/cmd/completion/audit.go
@@ -9,7 +9,7 @@ import (
 )
 
 func (c *Completion) AuditPhase(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-	return []string{apiv2.AuditPhase_AUDIT_PHASE_REQUEST.String(), apiv2.AuditPhase_AUDIT_PHASE_RESPONSE.String()}, cobra.ShellCompDirectiveNoFileComp
+	return c.genericEnums(apiv2.AuditPhase_name)
 }
 
 func (c *Completion) AuditStatusCodes(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {

--- a/cmd/completion/completion.go
+++ b/cmd/completion/completion.go
@@ -13,3 +13,17 @@ type Completion struct {
 func OutputFormat(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 	return []string{"table", "wide", "markdown", "json", "yaml", "template"}, cobra.ShellCompDirectiveNoFileComp
 }
+
+func (c *Completion) genericEnums(enums map[int32]string) ([]string, cobra.ShellCompDirective) {
+	var names []string
+
+	for id, name := range enums {
+		if id == 0 {
+			// skip UNSPECIFIED
+			continue
+		}
+		names = append(names, name)
+	}
+
+	return names, cobra.ShellCompDirectiveNoFileComp
+}

--- a/cmd/completion/component.go
+++ b/cmd/completion/component.go
@@ -6,11 +6,5 @@ import (
 )
 
 func (c *Completion) ComponentTypes(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-	var names []string
-
-	for _, name := range apiv2.ComponentType_name {
-		names = append(names, name)
-	}
-
-	return names, cobra.ShellCompDirectiveNoFileComp
+	return c.genericEnums(apiv2.ComponentType_name)
 }

--- a/cmd/completion/machine.go
+++ b/cmd/completion/machine.go
@@ -69,11 +69,5 @@ func (c *Completion) Firewall(cmd *cobra.Command, args []string, toComplete stri
 }
 
 func (c *Completion) BMCCommands(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-	var names []string
-
-	for _, name := range apiv2.MachineBMCCommand_name {
-		names = append(names, name)
-	}
-
-	return names, cobra.ShellCompDirectiveNoFileComp
+	return c.genericEnums(apiv2.MachineBMCCommand_name)
 }

--- a/cmd/tableprinters/switch.go
+++ b/cmd/tableprinters/switch.go
@@ -21,7 +21,7 @@ func (t *TablePrinter) SwitchTable(switches []*apiv2.Switch, wide bool) ([]strin
 		rows [][]string
 	)
 
-	header := []string{"ID", "Partition", "Rack", "OS", "Status", "Last Sync"}
+	header := []string{"ID", "Partition", "Rack", "OS", "Metalcore", "Status", "Last Sync"}
 	if wide {
 		header = []string{"ID", "Partition", "Rack", "OS", "Metalcore", "IP", "Mode", "Last Sync", "Sync Duration", "Last Error"}
 		t.t.DisableAutoWrap(true)
@@ -171,7 +171,7 @@ func (t *TablePrinter) SwitchTable(switches []*apiv2.Switch, wide bool) ([]strin
 		if wide {
 			rows = append(rows, []string{id, partition, rack, os, metalCore, s.ManagementIp, mode, syncLast, syncDurStr, lastError})
 		} else {
-			rows = append(rows, []string{id, partition, rack, osIcon, shortStatus, syncLast})
+			rows = append(rows, []string{id, partition, rack, osIcon, metalCore, shortStatus, syncLast})
 		}
 	}
 

--- a/cmd/tableprinters/switch_test.go
+++ b/cmd/tableprinters/switch_test.go
@@ -168,7 +168,7 @@ func TestTablePrinter_SwitchTable(t *testing.T) {
 			name:       "switches empty",
 			switches:   []*apiv2.Switch{},
 			wide:       false,
-			wantHeader: []string{"ID", "Partition", "Rack", "OS", "Status", "Last Sync"},
+			wantHeader: []string{"ID", "Partition", "Rack", "OS", "Metalcore", "Status", "Last Sync"},
 			wantRows:   nil,
 		},
 		{
@@ -266,15 +266,15 @@ func TestTablePrinter_SwitchTable(t *testing.T) {
 				},
 			},
 			wide:       false,
-			wantHeader: []string{"ID", "Partition", "Rack", "OS", "Status", "Last Sync"},
+			wantHeader: []string{"ID", "Partition", "Rack", "OS", "Metalcore", "Status", "Last Sync"},
 			wantRows: [][]string{
 				// FIXME: color of the dots is ignored; how to test for correct colors?
-				{"r01leaf01", "partition-a", "rack01", "🦔", color.GreenString(dot), "0s ago"},                                                      // status green but error because one port is not in its desired state
-				{"r01leaf02", "partition-a", "rack01", "🐢", nbr + color.RedString(dot), "0s ago"},                                                  // status red because in replace mode
-				{"r02leaf01", "partition-a", "rack02", apiv2.SwitchOSVendor_SWITCH_OS_VENDOR_UNSPECIFIED.String(), color.RedString(dot), "1h ago"}, // status red because last error came later than last sync
-				{"r02leaf02", "partition-a", "rack02", "", color.RedString(dot), "10m ago"},                                                        // status red because last sync is too long ago
-				{"r03leaf01", "partition-a", "rack03", "", color.YellowString(dot), "0s ago"},                                                      // status yellow because last sync duration was too long
-				{"r03leaf02", "partition-a", "rack03", "", color.YellowString(dot), ""},                                                            // status yellow because not all connceted ports are up
+				{"r01leaf01", "partition-a", "rack01", "🦔", "",color.GreenString(dot), "0s ago"},                                                      // status green but error because one port is not in its desired state
+				{"r01leaf02", "partition-a", "rack01", "🐢","", nbr + color.RedString(dot), "0s ago"},                                                  // status red because in replace mode
+				{"r02leaf01", "partition-a", "rack02", apiv2.SwitchOSVendor_SWITCH_OS_VENDOR_UNSPECIFIED.String(), "",color.RedString(dot), "1h ago"}, // status red because last error came later than last sync
+				{"r02leaf02", "partition-a", "rack02", "", "",color.RedString(dot), "10m ago"},                                                        // status red because last sync is too long ago
+				{"r03leaf01", "partition-a", "rack03", "", "",color.YellowString(dot), "0s ago"},                                                      // status yellow because last sync duration was too long
+				{"r03leaf02", "partition-a", "rack03", "", "",color.YellowString(dot), ""},                                                            // status yellow because not all connceted ports are up
 			},
 		},
 		{

--- a/cmd/tableprinters/switch_test.go
+++ b/cmd/tableprinters/switch_test.go
@@ -269,12 +269,12 @@ func TestTablePrinter_SwitchTable(t *testing.T) {
 			wantHeader: []string{"ID", "Partition", "Rack", "OS", "Metalcore", "Status", "Last Sync"},
 			wantRows: [][]string{
 				// FIXME: color of the dots is ignored; how to test for correct colors?
-				{"r01leaf01", "partition-a", "rack01", "🦔", "",color.GreenString(dot), "0s ago"},                                                      // status green but error because one port is not in its desired state
-				{"r01leaf02", "partition-a", "rack01", "🐢","", nbr + color.RedString(dot), "0s ago"},                                                  // status red because in replace mode
-				{"r02leaf01", "partition-a", "rack02", apiv2.SwitchOSVendor_SWITCH_OS_VENDOR_UNSPECIFIED.String(), "",color.RedString(dot), "1h ago"}, // status red because last error came later than last sync
-				{"r02leaf02", "partition-a", "rack02", "", "",color.RedString(dot), "10m ago"},                                                        // status red because last sync is too long ago
-				{"r03leaf01", "partition-a", "rack03", "", "",color.YellowString(dot), "0s ago"},                                                      // status yellow because last sync duration was too long
-				{"r03leaf02", "partition-a", "rack03", "", "",color.YellowString(dot), ""},                                                            // status yellow because not all connceted ports are up
+				{"r01leaf01", "partition-a", "rack01", "🦔", "", color.GreenString(dot), "0s ago"},                                                      // status green but error because one port is not in its desired state
+				{"r01leaf02", "partition-a", "rack01", "🐢", "", nbr + color.RedString(dot), "0s ago"},                                                  // status red because in replace mode
+				{"r02leaf01", "partition-a", "rack02", apiv2.SwitchOSVendor_SWITCH_OS_VENDOR_UNSPECIFIED.String(), "", color.RedString(dot), "1h ago"}, // status red because last error came later than last sync
+				{"r02leaf02", "partition-a", "rack02", "", "", color.RedString(dot), "10m ago"},                                                        // status red because last sync is too long ago
+				{"r03leaf01", "partition-a", "rack03", "", "", color.YellowString(dot), "0s ago"},                                                      // status yellow because last sync duration was too long
+				{"r03leaf02", "partition-a", "rack03", "", "", color.YellowString(dot), ""},                                                            // status yellow because not all connceted ports are up
 			},
 		},
 		{

--- a/tests/e2e/admin/switch_test.go
+++ b/tests/e2e/admin/switch_test.go
@@ -84,9 +84,9 @@ func Test_AdminSwitchCmd_List(t *testing.T) {
 				},
 			}),
 			WantTable: new(`
-            ID      PARTITION  RACK    OS  STATUS  LAST SYNC
-            leaf01  fra-equ01  rack-1  🦔  ●
-            leaf02  fra-equ01  rack-1  🦔  ●
+            ID      PARTITION  RACK    OS  METALCORE         STATUS  LAST SYNC  
+            leaf01  fra-equ01  rack-1  🦔  v0.9.1 (abc1234)  ●                  
+            leaf02  fra-equ01  rack-1  🦔  v0.9.1 (abc1234)  ●
             `),
 			WantWideTable: new(`
             ID      PARTITION  RACK    OS             METALCORE         IP        MODE         LAST SYNC  SYNC DURATION  LAST ERROR
@@ -99,10 +99,10 @@ leaf01 fra-equ01
 leaf02 fra-equ01
             `),
 			WantMarkdown: new(`
-            | ID     | PARTITION | RACK   | OS | STATUS | LAST SYNC |
-            |--------|-----------|--------|----|--------|-----------|
-            | leaf01 | fra-equ01 | rack-1 | 🦔 | ●      |           |
-            | leaf02 | fra-equ01 | rack-1 | 🦔 | ●      |           |
+            | ID     | PARTITION | RACK   | OS | METALCORE        | STATUS | LAST SYNC |
+            |--------|-----------|--------|----|------------------|--------|-----------|
+            | leaf01 | fra-equ01 | rack-1 | 🦔 | v0.9.1 (abc1234) | ●      |           |
+            | leaf02 | fra-equ01 | rack-1 | 🦔 | v0.9.1 (abc1234) | ●      |           |
             `),
 		},
 	}
@@ -167,8 +167,8 @@ func Test_AdminSwitchCmd_Update(t *testing.T) {
 					},
 				}),
 			WantTable: new(`
-            ID      PARTITION  RACK    OS  STATUS  LAST SYNC
-            leaf02  fra-equ01  rack-1  🦔  ●
+            ID      PARTITION  RACK    OS  METALCORE         STATUS  LAST SYNC  
+            leaf02  fra-equ01  rack-1  🦔  v0.9.1 (abc1234)  ●
                     `),
 			WantWideTable: new(`
             ID      PARTITION  RACK    OS             METALCORE         IP        MODE         LAST SYNC  SYNC DURATION  LAST ERROR
@@ -177,9 +177,9 @@ func Test_AdminSwitchCmd_Update(t *testing.T) {
 			Template:     new("{{ .id }} {{ .os.metal_core_version }}"),
 			WantTemplate: new(`leaf02 v0.9.1 (abc1234), tags/v0.9.1`),
 			WantMarkdown: new(`
-            | ID     | PARTITION | RACK   | OS | STATUS | LAST SYNC |
-            |--------|-----------|--------|----|--------|-----------|
-            | leaf02 | fra-equ01 | rack-1 | 🦔 | ●      |           |
+            | ID     | PARTITION | RACK   | OS | METALCORE        | STATUS | LAST SYNC |
+            |--------|-----------|--------|----|------------------|--------|-----------|
+            | leaf02 | fra-equ01 | rack-1 | 🦔 | v0.9.1 (abc1234) | ●      |           |
                     `),
 		},
 	}


### PR DESCRIPTION
## Description

- Unify Eum completions where possible
- Show metal-core version in short switch list

#### Used AI-Tools ✨

<!-- If not used, delete the next section.

For commits with substantial parts that were generated by AI, please also mark the commits with the Generated-By: [tool name] label as described in our contribution guideline: https://metal-stack.io/community/contribution-guideline/#usage-of-generative-ai-tools.
 -->

- None used for generation

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
You maybe want to attach the triage label if you want it to be discussed in the next planning meeting. It might be useful to attend the meeting if you want to emphasize it.

If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
